### PR TITLE
Make sure to free memory when calling setSrcImage.

### DIFF
--- a/index.html
+++ b/index.html
@@ -35,141 +35,138 @@
   <script>
 
     // Module is our Web Assembly instance
-    var Module = {
-      // When the instance has been loaded and compiled...
-      onRuntimeInitialized: () => {
+    var JPEGLoaderInstance = JPEGLoaderModule().then(function(Module) {
 
-        // JS wrap of : Image* setSrcImage(BYTE* jpegData, ULONG size)
-        let setSrcImage = Module.cwrap('setSrcImage', 'number', ['number', 'number']);
-        // JS wrap of : Image* compress(ULONG quality)
-        let compress = Module.cwrap('compress', 'number', ['number']);
-        // Canvas
-        let displayZone = {
-          ctx: undefined,       // canvas context
-          bmpArray: undefined,  // bitmap data
-          imageData: undefined  // internal canvas bitmap data
-        };
-        // The following object maps the C Image structure
-        let image = {
-          width: undefined,
-          height: undefined,
-          compressedSize: undefined,
-          data: undefined
-        }
-
-        // Start point...
-        loadSrcImage("libjpeg/testimg.jpg");
-
-        function loadSrcImage(imgUrl) {
-          fetch(imgUrl)
-            .then(response => response.arrayBuffer())
-            .then(initImage)
-            .then(createDisplayZone)
-            .then(() => update(1));
-        }
-
-        function initImage(rawJpeg) {
-          // the fetch response is an ArrayBuffer (not typed).
-          // We create a typed array from it.
-          let rawJpegAsTypedArray = new Uint8Array(rawJpeg);
-          // We allocate a memory block inside our WebAssembly module using the libc malloc function
-          // given by the emscripten glue code.
-          let srcBuf = Module._malloc(rawJpegAsTypedArray.length * rawJpegAsTypedArray.BYTES_PER_ELEMENT);
-          // We copy the typed array to the memory block
-          // Important : this memory block is a part of the heap. 
-          // The heap is allocated by JS code in the Emscripten glue and 
-          // given as the memory to the WebAssembly instance.
-          // So, when we do malloc we simply get an index into the heap where 
-          // we can write. This is done by writeArrayToMemory which will
-          // simply call HEAP8.set(array, buffer), which means : 
-          // "copy array to HEAP8 at offset buffer"
-          Module.writeArrayToMemory(rawJpegAsTypedArray, srcBuf);
-          // We give setSrcImage the pointer to the raw Jpeg data in the heap.
-          // This function will return information about the bitmap :
-          // { ULONG width; ULONG height; ULONG compressedSize; BYTE* bmpData; }
-          let pImage = setSrcImage(srcBuf, rawJpegAsTypedArray.length);
-          // We get width and height from these informations
-          image.width = Module.getValue(pImage + 0, 'i32');
-          image.height = Module.getValue(pImage + 4, 'i32');
-          // We known our WebAssembly code will not use anymore the allocated memory block.
-          Module._free(srcBuf);
-          // And we will not need the raw data anymore.
-          delete rawJpegAsTypedArray;
-        }
-
-        function createDisplayZone() {
-          let canvas = document.createElement('canvas');
-          canvas.width = image.width;
-          canvas.height = image.height;
-          document.getElementById('image-container').appendChild(canvas);
-          displayZone.ctx = canvas.getContext('2d');
-          // The MSDN doc says Uint8ClampedArray but it does not work (colors are melted).
-          displayZone.bmpArray = new Uint8Array(image.width * image.height * 4).fill(0xff);
-          displayZone.imageData = displayZone.ctx.createImageData(image.width, image.height);
-        }
-
-        function display() {
-          // Unfortunatly, bitmap pixels are RGB and canvas expects RGBA.
-          // So we have to convert pixel by pixel, and it is slow !
-          // The canvas Alpha is set in createDisplayZone() with fill(0xff)
-          // To improve performance, we should make the Web Assembly code
-          // do the pixel conversion into an allocated RGBA pixels space.
-          let len = image.width * image.height * 4;
-          for (let ptr = image.data, iDst = 0; iDst < len; ptr += 3, iDst += 4) {
-            displayZone.bmpArray[iDst + 0] = Module.getValue(ptr + 0, 'i8');
-            displayZone.bmpArray[iDst + 1] = Module.getValue(ptr + 1, 'i8');
-            displayZone.bmpArray[iDst + 2] = Module.getValue(ptr + 2, 'i8');
-          }
-
-          // Following is an aborted performance optimization.
-          // Problem comes from memory alignment : read RGB to write RGBA
-          // implies moving from 3 bytes to 3 bytes. When reading a i32 value with 
-          // getValue, we are unaligned. As the doc says, results may be
-          // unpredictable.
-          // To ensure alignment you add -s SAFE_HEAP=1 to your emcc, 
-          // the getValue will then crash.
-          //
-          // let buf32 = new Uint32Array(image.width * image.height * 4);
-          // let len = image.width * image.height;
-          // for (let ptr = image.data, iDst = 0; iDst < len; ptr += 4, iDst += 1) {
-          //     let bytes = Module.getValue(ptr, 'i32'); // = RGBR, BRxx, B000                        
-          //     let a = 255;
-          //     let r = (bytes & 0xff000000) >> 24;
-          //     let g = (bytes & 0x00ff0000) >> 16;
-          //     let b = (bytes & 0x0000ff00) >> 8;
-          //     // buf32 format : ABGR
-          //     buf32[iDst] = (a << 24) | (b << 16) | (g << 8) | r;
-          // }
-          // displayZone.bmpArray = new Uint8ClampedArray(buf32.buffer);
-
-          // We need these two calls to trigger the canvas update
-          displayZone.imageData.data.set(displayZone.bmpArray);
-          displayZone.ctx.putImageData(displayZone.imageData, 0, 0);
-        }
-
-        // On slider move...
-        function update(quality) {
-          // Call the WebAssembly function compress()
-          // It will compress the bitmap image to Jpeg with given quality value.
-          // Then it will decompress back and return the bitmap structure (width, height, uncompressedSize, data)
-          let pImage = compress(quality);
-          image.compressedSize = getValue(pImage + 8, 'i32');
-          image.data = getValue(pImage + 12, 'i32');
-          document.getElementById('size').innerHTML = 'Quality:' + quality + ' / Weight: ' + (image.compressedSize / 1024).toFixed(2) + ' Kb';
-          // Show it to the world
-          display();
-          // The display function has copied the bitmap data to the canvas through
-          // an Uint8Array. Si, we do not need the bitmap structure anymore.
-          Module._free(image.data);
-          Module._free(pImage);
-        }
-
-        let slider = document.getElementById("quality");
-        slider.oninput = function () {
-          update(this.value);
-        };
+      // JS wrap of : Image* setSrcImage(BYTE* jpegData, ULONG size)
+      let setSrcImage = Module.cwrap('setSrcImage', 'number', ['number', 'number']);
+      // JS wrap of : Image* compress(ULONG quality)
+      let compress = Module.cwrap('compress', 'number', ['number']);
+      // Canvas
+      let displayZone = {
+        ctx: undefined,       // canvas context
+        bmpArray: undefined,  // bitmap data
+        imageData: undefined  // internal canvas bitmap data
+      };
+      // The following object maps the C Image structure
+      let image = {
+        width: undefined,
+        height: undefined,
+        compressedSize: undefined,
+        data: undefined
       }
-    };
+
+      // Start point...
+      loadSrcImage("libjpeg/testimg.jpg");
+
+      function loadSrcImage(imgUrl) {
+        fetch(imgUrl)
+          .then(response => response.arrayBuffer())
+          .then(initImage)
+          .then(createDisplayZone)
+          .then(() => update(1));
+      }
+
+      function initImage(rawJpeg) {
+        // the fetch response is an ArrayBuffer (not typed).
+        // We create a typed array from it.
+        let rawJpegAsTypedArray = new Uint8Array(rawJpeg);
+        // We allocate a memory block inside our WebAssembly module using the libc malloc function
+        // given by the emscripten glue code.
+        let srcBuf = Module._malloc(rawJpegAsTypedArray.length * rawJpegAsTypedArray.BYTES_PER_ELEMENT);
+        // We copy the typed array to the memory block
+        // Important : this memory block is a part of the heap. 
+        // The heap is allocated by JS code in the Emscripten glue and 
+        // given as the memory to the WebAssembly instance.
+        // So, when we do malloc we simply get an index into the heap where 
+        // we can write. This is done by writeArrayToMemory which will
+        // simply call HEAP8.set(array, buffer), which means : 
+        // "copy array to HEAP8 at offset buffer"
+        Module.writeArrayToMemory(rawJpegAsTypedArray, srcBuf);
+        // We give setSrcImage the pointer to the raw Jpeg data in the heap.
+        // This function will return information about the bitmap :
+        // { ULONG width; ULONG height; ULONG compressedSize; BYTE* bmpData; }
+        let pImage = setSrcImage(srcBuf, rawJpegAsTypedArray.length);
+        // We get width and height from these informations
+        image.width = Module.getValue(pImage + 0, 'i32');
+        image.height = Module.getValue(pImage + 4, 'i32');
+        // We known our WebAssembly code will not use anymore the allocated memory block.
+        Module._free(srcBuf);
+        // And we will not need the raw data anymore.
+        delete rawJpegAsTypedArray;
+      }
+
+      function createDisplayZone() {
+        let canvas = document.createElement('canvas');
+        canvas.width = image.width;
+        canvas.height = image.height;
+        document.getElementById('image-container').appendChild(canvas);
+        displayZone.ctx = canvas.getContext('2d');
+        // The MSDN doc says Uint8ClampedArray but it does not work (colors are melted).
+        displayZone.bmpArray = new Uint8Array(image.width * image.height * 4).fill(0xff);
+        displayZone.imageData = displayZone.ctx.createImageData(image.width, image.height);
+      }
+
+      function display() {
+        // Unfortunatly, bitmap pixels are RGB and canvas expects RGBA.
+        // So we have to convert pixel by pixel, and it is slow !
+        // The canvas Alpha is set in createDisplayZone() with fill(0xff)
+        // To improve performance, we should make the Web Assembly code
+        // do the pixel conversion into an allocated RGBA pixels space.
+        let len = image.width * image.height * 4;
+        for (let ptr = image.data, iDst = 0; iDst < len; ptr += 3, iDst += 4) {
+          displayZone.bmpArray[iDst + 0] = Module.getValue(ptr + 0, 'i8');
+          displayZone.bmpArray[iDst + 1] = Module.getValue(ptr + 1, 'i8');
+          displayZone.bmpArray[iDst + 2] = Module.getValue(ptr + 2, 'i8');
+        }
+
+        // Following is an aborted performance optimization.
+        // Problem comes from memory alignment : read RGB to write RGBA
+        // implies moving from 3 bytes to 3 bytes. When reading a i32 value with 
+        // getValue, we are unaligned. As the doc says, results may be
+        // unpredictable.
+        // To ensure alignment you add -s SAFE_HEAP=1 to your emcc, 
+        // the getValue will then crash.
+        //
+        // let buf32 = new Uint32Array(image.width * image.height * 4);
+        // let len = image.width * image.height;
+        // for (let ptr = image.data, iDst = 0; iDst < len; ptr += 4, iDst += 1) {
+        //     let bytes = Module.getValue(ptr, 'i32'); // = RGBR, BRxx, B000                        
+        //     let a = 255;
+        //     let r = (bytes & 0xff000000) >> 24;
+        //     let g = (bytes & 0x00ff0000) >> 16;
+        //     let b = (bytes & 0x0000ff00) >> 8;
+        //     // buf32 format : ABGR
+        //     buf32[iDst] = (a << 24) | (b << 16) | (g << 8) | r;
+        // }
+        // displayZone.bmpArray = new Uint8ClampedArray(buf32.buffer);
+
+        // We need these two calls to trigger the canvas update
+        displayZone.imageData.data.set(displayZone.bmpArray);
+        displayZone.ctx.putImageData(displayZone.imageData, 0, 0);
+      }
+
+      // On slider move...
+      function update(quality) {
+        // Call the WebAssembly function compress()
+        // It will compress the bitmap image to Jpeg with given quality value.
+        // Then it will decompress back and return the bitmap structure (width, height, uncompressedSize, data)
+        let pImage = compress(quality);
+        image.compressedSize = getValue(pImage + 8, 'i32');
+        image.data = getValue(pImage + 12, 'i32');
+        document.getElementById('size').innerHTML = 'Quality:' + quality + ' / Weight: ' + (image.compressedSize / 1024).toFixed(2) + ' Kb';
+        // Show it to the world
+        display();
+        // The display function has copied the bitmap data to the canvas through
+        // an Uint8Array. Si, we do not need the bitmap structure anymore.
+        Module._free(image.data);
+        Module._free(pImage);
+      }
+
+      let slider = document.getElementById("quality");
+      slider.oninput = function () {
+        update(this.value);
+      };
+    });
   </script>
 </body>
 

--- a/readme.md
+++ b/readme.md
@@ -43,7 +43,7 @@ We have now a WASM Jpeg library ready to be included into our project.
 Let's build our app :
 
     cd ..
-    emcc -o webassembly-jpeg.js jpeg-read.c jpeg-write.c webassembly-jpeg.c libjpeg/.libs/libjpeg.a -O3 -s WASM=1 -s NO_EXIT_RUNTIME=1 -s 'EXTRA_EXPORTED_RUNTIME_METHODS=["writeArrayToMemory","getValue", "cwrap"]' 
+    emcc -o webassembly-jpeg.js jpeg-read.c jpeg-write.c webassembly-jpeg.c libjpeg/.libs/libjpeg.a -O3 -s WASM=1 -s NO_EXIT_RUNTIME=1 -s MODULARIZE=1 -s 'EXPORT_NAME="JPEGLoaderModule"' -s 'EXPORTED_FUNCTIONS=["_malloc","_free"]' -s 'EXTRA_EXPORTED_RUNTIME_METHODS=["writeArrayToMemory","getValue", "cwrap"]'
 
 
 Launch a local server : 

--- a/webassembly-jpeg.c
+++ b/webassembly-jpeg.c
@@ -4,12 +4,15 @@
 #include <emscripten/emscripten.h>
 #include "webassembly-jpeg.h"
 
-Image *pSrcImage;
+Image *pSrcImage = NULL;
 
 Image *EMSCRIPTEN_KEEPALIVE setSrcImage(BYTE *jpegData, ULONG size)
 {
-    free(pSrcImage->data);
-    free(pSrcImage);
+    if (pSrcImage)
+    {
+        free(pSrcImage->data);
+        free(pSrcImage);
+    }
     pSrcImage = readJpeg(jpegData, size);
     EM_ASM({ console.log('setSrcImage done'); });
     return pSrcImage;

--- a/webassembly-jpeg.c
+++ b/webassembly-jpeg.c
@@ -8,6 +8,8 @@ Image *pSrcImage;
 
 Image *EMSCRIPTEN_KEEPALIVE setSrcImage(BYTE *jpegData, ULONG size)
 {
+    free(pSrcImage->data);
+    free(pSrcImage);
     pSrcImage = readJpeg(jpegData, size);
     EM_ASM({ console.log('setSrcImage done'); });
     return pSrcImage;


### PR DESCRIPTION
Updated WASM module to use EXPORT_NAME and MODULARIZE, so it'll be possible to run more than one instance on a page.